### PR TITLE
Upgrade to 4.7.0

### DIFF
--- a/blueprints/ember-cli-tachyons-shim/index.js
+++ b/blueprints/ember-cli-tachyons-shim/index.js
@@ -8,7 +8,7 @@ module.exports = {
 
 	afterInstall: function (options) {
 		var promise = new Promise((resolve, reject) => {
-			this.addPackageToProject('tachyons', '4.6.1').then((success) => {
+			this.addPackageToProject('tachyons', '4.7.0').then((success) => {
 				try {
 					var fs = require('fs');
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"glob": "^7.1.1",
 		"loader.js": "^4.0.10",
 		"mocha": "^3.1.0",
-		"tachyons": "^4.6.1"
+		"tachyons": "4.7.0"
 	},
 	"engines": {
 		"node": ">= 0.12.0"


### PR DESCRIPTION
#69 should be merged first, as the tests currently fail when using an older Ember-CLI version :man_shrugging:.